### PR TITLE
Check inkscape filename matching actual filename

### DIFF
--- a/.github/workflows/meta_data.yaml
+++ b/.github/workflows/meta_data.yaml
@@ -9,5 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
       - name: Check svg
         run: ./scripts/check_svg_meta.sh

--- a/mapres/desert_main.svg
+++ b/mapres/desert_main.svg
@@ -7,7 +7,7 @@
    width="1024"
    height="1024"
    viewBox="0 0 1024 1024"
-   sodipodi:docname="desert_main_nh.svg"
+   sodipodi:docname="desert_main.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xml:space="preserve"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/mapres/grass_doodads_0.7.svg
+++ b/mapres/grass_doodads_0.7.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 1024 1024"
    version="1.1"
    id="SVGRoot"
-   sodipodi:docname="grass_doodads_chiller.svg"
+   sodipodi:docname="grass_doodads_0.7.svg"
    inkscape:version="1.1-dev (cef4a25b16, 2020-10-10)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/mapres/grass_main.svg
+++ b/mapres/grass_main.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 1024 1024"
    version="1.1"
    id="SVGRoot"
-   sodipodi:docname="grass_main_chiller.svg"
+   sodipodi:docname="grass_main.svg"
    inkscape:version="1.2-dev (3978b257e3, 2021-12-14)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/scripts/check_svg_meta.sh
+++ b/scripts/check_svg_meta.sh
@@ -3,6 +3,11 @@
 err=0
 arg_fix=0
 
+error() {
+	printf '[-] ERROR: %s\n' "$1" 1>&2
+	err="$((err+1))"
+}
+
 for arg in "$@"
 do
 	if [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "help" ]
@@ -21,35 +26,92 @@ do
 	fi
 done
 
-while IFS= read -r file
-do
+# prefix your keys with dot
+# this is a wrapper around jq
+xml_get_key() {
+	local key="$1"
+	local file="$2"
+	if yq --version | grep -qF 'https://github.com/mikefarah/yq'
+	then
+		yq -r -p xml -o json "$key" "$file"
+	else
+		local potential_keys
+		[[ "$key" =~ ^\.svg\[[\"\']\+@(.*)[\"\']\]$ ]] && key="${BASH_REMATCH[1]}"
+		potential_keys="$(grep -F "$key=" "$file")"
+		local num_matches
+		num_matches="$(printf '%s' "$potential_keys" | wc -l)"
+		if [ "$num_matches" -lt 2 ] && [ "$potential_keys" != "" ]
+		then
+			printf '%s' "$potential_keys" | cut -d'"' -f2
+			return
+		fi
+
+		local grep_safe_key
+		grep_safe_key="$(printf '%s' "$key" | grep -o '[a-ZA-Z0-9]')"
+		potential_keys="$(printf '%s' "$potential_keys" | grep "^[[:space:]]*$grep_safe_key")"
+		num_matches="$(printf '%s' "$potential_keys" | wc -l)"
+		if [ "$num_matches" = 0 ]
+		then
+			printf null
+			return
+		fi
+		printf '%s' "$potential_keys" | head -n1 | cut -d'"' -f2
+	fi
+}
+
+check_meta_filename_match() {
+	local file="$1"
+	local expected_filename
+	expected_filename="$(basename "$file")"
+	local actual_filename
+	if ! actual_filename="$(xml_get_key '.svg["+@sodipodi:docname"]' "$file")"
+	then
+		error "failed to get meta filename of $file"
+		exit 1
+	fi
+	[ "$actual_filename" = null ] && return
+
+	if [ "$actual_filename" != "$expected_filename" ]
+	then
+		error "svg docname does not match filename in $file"
+		printf '\n    expected: "%s"' "$expected_filename" 1>&2
+		printf '\n         got: "%s"\n\n' "$actual_filename" 1>&2
+	fi
+}
+
+check_absolute_path() {
+	local file="$1"
 	if [ "$arg_fix" == "1" ]
 	then
 		sed -i -r '/export-filename="([A-Z]:|\/)/d' "$file"
-		continue
+		return
 	fi
 	while IFS= read -r line
 	do
-		printf "[-] ERROR: absolute export path found in %s:%d\\n" \
-			"$file" \
-			"$(echo "$line" | cut -d':' -f1)"
-		err="$((err+1))"
+		error "absolute export path found in $file:$(echo "$line" | cut -d':' -f1)"
 	done < <(grep -nE 'export-filename="([A-Z]:\\|/)' "$file")
+}
 
-	# check if there is width and height parameter
+check_width_height() {
+	local file="$1"
 	width_found=$(grep -Eiwzo "<svg[^>]*>" "$file" | tr '\0' '\n' | grep -Eo "width=\"([0-9.]|px)*\"")
 	height_found=$(grep -Eiwzo "<svg[^>]*>" "$file" | tr '\0' '\n' | grep -Eo "height=\"([0-9.]|px)*\"")
 
 	if [[ "$width_found" == "" || "$height_found" == "" ]]
 	then
-		printf "[-] ERROR: no width or height parameter found in %s\\n" "$file"
-		err="$((err+1))"
+		error "no width or height parameter found in $file"
 	fi
 	if grep -qF 'xlink:href="data:image/png;base64,' "$file"
 	then
-		printf "[-] ERROR: embedded image found %s\\n" "$file"
-		err="$((err+1))"
+		error "embedded image found $file"
 	fi
+}
+
+while IFS= read -r file
+do
+	check_absolute_path "$file"
+	check_meta_filename_match "$file"
+	check_width_height "$file"
 done < <(find . -type f -name "*.svg")
 
 if [ "$err" -ne "0" ]

--- a/scripts/check_svg_meta.sh
+++ b/scripts/check_svg_meta.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-err=0
+num_errors=0
+num_warnings=0
 arg_fix=0
 
 error() {
 	printf '[-] ERROR: %s\n' "$1" 1>&2
-	err="$((err+1))"
+	num_errors="$((num_errors+1))"
+}
+
+warning() {
+	printf '[-] WARNING: %s\n' "$1" 1>&2
+	num_warnings="$((num_warnings+1))"
 }
 
 for arg in "$@"
@@ -73,7 +79,7 @@ check_meta_filename_match() {
 
 	if [ "$actual_filename" != "$expected_filename" ]
 	then
-		error "svg docname does not match filename in $file"
+		warning "svg docname does not match filename in $file"
 		printf '\n    expected: "%s"' "$expected_filename" 1>&2
 		printf '\n         got: "%s"\n\n' "$actual_filename" 1>&2
 	fi
@@ -114,10 +120,15 @@ do
 	check_width_height "$file"
 done < <(find . -type f -name "*.svg")
 
-if [ "$err" -ne "0" ]
+if [ "$num_errors" -ne "0" ]
 then
-	echo "[-] failed ($err errors)"
+	echo "[-] failed ($num_errors errors)"
 	exit 1
+fi
+if [ "$num_warnings" -ne "0" ]
+then
+	echo "[!] finished ($num_warnings warnings)"
+	exit 0
 fi
 
 echo "[+] done"

--- a/skins/cammostripes.svg
+++ b/skins/cammostripes.svg
@@ -15,7 +15,7 @@
    inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
-   sodipodi:docname="cammostripe.svg">
+   sodipodi:docname="cammostripes.svg">
   <defs
      id="defs2" />
   <sodipodi:namedview


### PR DESCRIPTION
Added the optional dependency yq for xml parsing. But falls back to a 20 lines bash self rolled xml parser (what could possibly go wrong). There is no --fix that seemed to complex and error prone. So users have to fix it manually. That could potentially be annoying. We could also make it a warning instead of an error.

Also refactored all errors.

And structured the code into functions.