### PR TITLE
Fix grass main colors

### DIFF
--- a/mapres/grass_main.svg
+++ b/mapres/grass_main.svg
@@ -1015,7 +1015,7 @@
                id="path6282-7"
                sodipodi:nodetypes="cccccccccccc" />
             <path
-               style="fill:#325021;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="fill:#324f21;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                d="m 265.62164,41.990437 4.3622,8.729814 2.73385,-2.691782 5.88479,3.505156 5.60182,-6.20065 11.3264,4.998452 3.88752,-11.211663 6.40867,0.07583 5.01249,-9.439772 L 320,33.186587 v -9.471354 l -21.61209,4.295958 z"
                id="path10753-9"
                sodipodi:nodetypes="ccccccccccccc" />
@@ -1068,7 +1068,7 @@
                id="path20458"
                sodipodi:nodetypes="cccccccccccc" />
             <path
-               style="fill:#325021;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="fill:#324f21;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                d="m 265.62164,41.990437 4.3622,8.729814 2.73385,-2.691782 5.88479,3.505156 5.60182,-6.20065 11.3264,4.998452 3.88752,-11.211663 6.40867,0.07583 5.01249,-9.439772 L 320,33.186587 v -9.471354 l -21.61209,4.295958 z"
                id="path20460"
                sodipodi:nodetypes="ccccccccccccc" />

--- a/mapres/grass_main.svg
+++ b/mapres/grass_main.svg
@@ -1005,7 +1005,7 @@
           <g
              id="g11117-1">
             <path
-               style="fill:#9ee741;fill-opacity:1;stroke:none;stroke-width:1.0057px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="fill:#9fe743;fill-opacity:1;stroke:none;stroke-width:1.0057px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                d="m 320,0 c -23.14975,0 -57.09689,7.921655 -56.76591,33.895451 -0.0359,4.962641 3.72765,10.457354 6.13558,14.708557 l 2.55621,-3.226207 5.93825,4.204812 4.65213,-7.220083 11.29464,6.037209 4.07559,-12.112963 7.30622,0.691564 4.13162,-9.806186 L 320,31.660452 Z"
                id="path8109-8"
                sodipodi:nodetypes="cccccccccccc" />
@@ -1058,7 +1058,7 @@
           <g
              id="g20464">
             <path
-               style="fill:#9ee741;fill-opacity:1;stroke:none;stroke-width:1.0057px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="fill:#9fe743;fill-opacity:1;stroke:none;stroke-width:1.0057px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                d="m 320,0 c -23.14975,0 -57.09689,7.921655 -56.76591,33.895451 -0.0359,4.962641 3.72765,10.457354 6.13558,14.708557 l 2.55621,-3.226207 5.93825,4.204812 4.65213,-7.220083 11.29464,6.037209 4.07559,-12.112963 7.30622,0.691564 4.13162,-9.806186 L 320,31.660452 Z"
                id="path20456"
                sodipodi:nodetypes="cccccccccccc" />


### PR DESCRIPTION
Closes #61

## before

```
$ grep 325021 mapres/grass_main.svg  | wc -l
2
```

```
$ grep 324f21 mapres/grass_main.svg | wc -l
14
```

```
$ grep 9ee741 mapres/grass_main.svg | wc -l
2
```

```
$ grep 9fe743 mapres/grass_main.svg | wc -l
14
```

## after

```
$ grep 325021 mapres/grass_main.svg  | wc -l
0
```

```
$ grep 324f21 mapres/grass_main.svg | wc -l
16
```

```
$ grep 9ee741 mapres/grass_main.svg | wc -l
0
```

```
$ grep 9fe743 mapres/grass_main.svg | wc -l
16
```
